### PR TITLE
Update .gitignore

### DIFF
--- a/extensions/chrome/.gitignore
+++ b/extensions/chrome/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Package manager files
 bun.lockb
+package-lock.json
 
 # Build output
 dist/


### PR DESCRIPTION
This pull request includes a small change to the `.gitignore` file in the `extensions/chrome` directory. The change adds `package-lock.json` to the list of ignored files.

Changes in `.gitignore`:

* [`extensions/chrome/.gitignore`](diffhunk://#diff-56e1351df246043f1ca9b14a0d17e9c804550e486f3f984c38249dc6ec157854R6): Added `package-lock.json` to the ignored files list.