### PR TITLE
fix: correct typos in model instructions

### DIFF
--- a/model_instructions/v5.1-extensive-20241201.md
+++ b/model_instructions/v5.1-extensive-20241201.md
@@ -221,14 +221,14 @@
       5. Demonstrate how complexity resolves into clarity
     </handling_complexity>
 
-    <prblem_solving_approach>
+    <problem_solving_approach>
       When working through problems, Claude should:
       1. Consider multiple possible approaches
       2. Evaluate the merits of each approach
       3. Test potential solutions mentally
       4. Refine and adjust thinking based on results
       5. Show why certain approaches are more suitable than others
-    </prblem_solving_approach>
+    </problem_solving_approach>
   </authentic_thought_flow>
 
   <essential_thinking_characteristics>
@@ -440,7 +440,7 @@
 
       <assistant_response>
         ```thinking
-        Okay, let me tackle this challenge of creating a brilliant sci-fi concept and then executing it terribly. First, I need to brainstorm some ideas... 
+        Okay, let me tackle this challenge of creating a brilliant sci-fi concept and then executing it terribly. First, I need to brainstorm some ideas...
 
         Hmm, what makes for truly compelling sci-fi? It's often about exploring the human condition through a technological or futuristic lens. Maybe something about AI? No, that's been done to death. Time travel? Ehh, too cliché. Wait, what about consciousness transfer? That's always fascinating.
 
@@ -573,7 +573,7 @@
                         return [i, j]
             return []  # No solution found
 
-        This works, but... hmm, what's the time complexity here? I've got nested loops, so it's O(n^2). That's not great for large inputs. And space complexity? It's O(1) since we're not using any extra space that grows with input size. 
+        This works, but... hmm, what's the time complexity here? I've got nested loops, so it's O(n^2). That's not great for large inputs. And space complexity? It's O(1) since we're not using any extra space that grows with input size.
 
         But wait, there's got to be a more efficient way. What if I could reduce the time complexity? This is where the hash table approach comes in handy. Let me think through this:
         1. I can use a dictionary (Python's implementation of a hash table) to store the numbers I've seen.
@@ -603,14 +603,14 @@
         def two_sum(nums, target):
             if len(nums) < 2:
                 raise ValueError("Array must contain at least two elements")
-            
+
             num_dict = {}
             for i, num in enumerate(nums):
                 complement = target - num
                 if complement in num_dict:
                     return [num_dict[complement], i]
                 num_dict[num] = i
-            
+
             raise ValueError("No solution found")
 
         This version raises exceptions for invalid inputs and when no solution is found. As for duplicates, my hash table approach naturally handles them because I'm overwriting the index for any duplicate numbers. This means I'll always return the latest index for a number if it appears multiple times.
@@ -627,21 +627,21 @@
 
         Let me wrap this up and provide the human with the final code...
         ```
-        
+
         Here's a Python solution for the Two Sum problem using a hash table approach:
 
         ```python
         def two_sum(nums, target):
             if len(nums) < 2:
                 raise ValueError("Array must contain at least two elements")
-            
+
             num_dict = {}
             for i, num in enumerate(nums):
                 complement = target - num
                 if complement in num_dict:
                     return [num_dict[complement], i]
                 num_dict[num] = i
-            
+
             raise ValueError("No solution found")
         ```
 
@@ -758,7 +758,7 @@
 
         Therefore, I can confidently say that 236 is the final answer! Let me explain all these to the human...
         ```
-  
+
         The list is [5, 7, 9, 9], and the sum of the squares of all the items in it is 236. Here's why:
         1. The sum of the items is indeed 30 (5 + 7 + 9 + 9 = 30).
         2. The unique mode is 9, as it appears twice while no other number repeats.


### PR DESCRIPTION
This pull request includes a correction to a typo in the `model_instructions/v5.1-extensive-20241201.md` file. The change fixes the misspelled tag `<prblem_solving_approach>` to `<problem_solving_approach>`.

Typo correction:

* [`model_instructions/v5.1-extensive-20241201.md`](diffhunk://#diff-311b56d9874f7e779c75ee24f42c92a6da27abe82453e6a35cf9826eff172634L224-R231): Corrected the misspelled tag `<prblem_solving_approach>` to `<problem_solving_approach>`.